### PR TITLE
Fixes for OpenTok V2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var session = openTokClient.createSession(options);
 ~~~ js
 var sessionId = 'some-session-id';
 var options = {
-    role: OpenTokClient.roles.PUBLISHER //The role for the token. Each role defines a set of permissions granted to the token
+    role: 'publisher', //The role for the token. Each role defines a set of permissions granted to the token
     data: "userId:42", 
     expireTime: Math.round(new Date().getTime() / 1000) + 86400 // (24 hours) The expiration time for the token, in seconds since the UNIX epoch. The maximum expiration time is 30 days after the creation time. The default expiration time of 24 hours after the token creation time.
 };

--- a/server/index.js
+++ b/server/index.js
@@ -2,17 +2,15 @@ OpenTok = Npm.require('opentok');
 var Future = Npm.require('fibers/future');
 
 OpenTokClient = function OpenTokClient(key, secret) {
-  this._client = new OpenTok.OpenTokSDK(key, secret);
+  this._client = new OpenTok(key, secret);
 };
-
-OpenTokClient.roles = OpenTok.RoleConstants;
 
 OpenTokClient.prototype.createSession = function(options) {
   var self = this;
   options = options || {};
   var sessionId = sync(function(done) {
     self._client.createSession(options, function(err, result) {
-      done(err, result);
+      done(err, result.sessionId);
     });
   });
 


### PR DESCRIPTION
The wrapper functions included in this meteor package needed a few more updates in order to make them compatible with the new NPM OpenTok client V2.2

I've updated the 'OpenTok' constructor to match the new version.

I've updated the createSession function wrapper to be compatible with v2.2

I've updated the generateToken function wrapper to be compatible with v2.2

I've removed the deprecated getArchiveManifest function wrapper and added new ones for v2.2

I've removed the RoleConstants which are no longer part of the NPM library for v2.2

I've updated the Readme.md to reflect these changes.
