### PR TITLE
Return archive instances instead of null errors when starting/stopping an archive

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -25,8 +25,8 @@ OpenTokClient.prototype.generateToken = function(sessionId, options) {
 OpenTokClient.prototype.startArchive = function(sessionId, options) {
   var self = this;
   var archive = sync(function(done) {
-    self._client.startArchive(sessionId, options, function(result) {
-      done(null, result);
+    self._client.startArchive(sessionId, options, function(err, result) {
+      done(err, result);
     });
   });
 
@@ -36,8 +36,8 @@ OpenTokClient.prototype.startArchive = function(sessionId, options) {
 OpenTokClient.prototype.stopArchive = function(sessionId) {
   var self = this;
   var archive = sync(function(done) {
-    self._client.stopArchive(sessionId, function(result) {
-      done(null, result);
+    self._client.stopArchive(sessionId, function(err, result) {
+      done(err, result);
     });
   });
 


### PR DESCRIPTION
Added errors to start and stop archive code, as it was returning the error instead of the archive instance by default, resulting in a null error being returned instead of an archive instance when the command was called.
